### PR TITLE
Revert "rebuild with build=1 (#66)"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,7 +47,7 @@ install:
     - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda.exe install -n root --quiet --yes conda-forge-ci-setup=1 conda-build=3.8
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-ci-setup=1
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.

--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -56,7 +56,7 @@ echo "$config" > ~/.condarc
 conda clean --lock
 
 # Make sure we pull in the latest conda-build version too
-conda install --yes --quiet conda-forge-ci-setup=1 conda-build=3.8
+conda install --yes --quiet conda-forge-ci-setup=1 conda-build
 source run_conda_forge_build_setup
 
 conda build /home/conda/recipe_root -m /home/conda/feedstock_root/.ci_support/${CONFIG}.yaml --quiet || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
       conda config --add channels defaults
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
-      conda install --yes --quiet conda-forge-ci-setup=1 conda-build=3.8
+      conda install --yes --quiet conda-forge-ci-setup=1
       source run_conda_forge_build_setup
 
 script:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   {{ hash_type }}: {{ hash }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
This reverts commit 5e729d76f45d7e8da366917dae5ab4e949c17e8c.

conda-build 3.9.2 should have the issue fixed

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
