### PR TITLE
add bash-completions definition for aws

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,8 @@ source:
 build:
   number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv  # [not unix]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv && echo complete -C aws_complete aws >aws && install -D aws $PREFIX/share/bash-completions/completions/aws  # [unix]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv && echo complete -C aws_complete aws >aws && install -D aws $PREFIX/share/bash-completions/completions/aws  # [linux]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv && echo complete -C aws_complete aws >aws && install -d aws $PREFIX/share/bash-completions/completions/aws  # [osx]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,13 +21,13 @@ source:
 build:
   number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv  # [not unix]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv && echo complete -C aws_complete aws >aws && install -D aws $PREFIX/share/bash-completions/completions/aws  # [linux]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv && echo complete -C aws_complete aws >aws && install -d aws $PREFIX/share/bash-completions/completions/aws  # [osx]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv && echo complete -C aws_complete aws >aws && ginstall -D aws $PREFIX/share/bash-completions/completions/aws  # [unix]
 
 requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - gnu-coreutils  # [unix]
   host:
     - python
 #    - python >=3.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,9 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps -vv  # [not unix]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv && echo complete -C aws_complete aws >aws && install -D aws $PREFIX/share/bash-completions/completions/aws  # [unix]
 
 requirements:
   build:
@@ -55,6 +56,9 @@ test:
     - awscli.customizations.gamelift
     - awscli.customizations.s3
     - awscli.customizations.s3.syncstrategy
+  commands:
+    - test -f $PREFIX/bin/aws_completer                   # [unix]
+    - COMP_LINE="aws ec2 describe-inst" aws_completer     # [unix]
 
 about:
   home: https://aws.amazon.com/cli/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,13 +21,12 @@ source:
 build:
   number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv  # [not unix]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv && echo complete -C aws_complete aws >aws && ginstall -D aws $PREFIX/share/bash-completions/completions/aws  # [unix]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv && mkdir -p $PREFIX/share/bash-completions/completions && echo complete -C aws_completer aws >$PREFIX/share/bash-completions/completions/aws  # [unix]
 
 requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - gnu-coreutils  # [unix]
   host:
     - python
 #    - python >=3.6


### PR DESCRIPTION
On unix, if bash-completions package is also installed, tab completion for
awscli will be enabled.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
