### PR TITLE
AWSCLI v2

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -83,11 +83,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "awscli" %}
-{% set version = "2.8.11" %}
+{% set version = "2.8.12" %}
+{% set hash = "a1f16a8e0bb7fb098967f852b074f431ec4adbdfa51e714129945c67a9798537" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +9,7 @@ package:
 # v2 is not on PyPI https://github.com/aws/aws-cli/issues/6785
 source:
   url: https://github.com/aws/aws-cli/archive/{{ version }}.tar.gz
-  sha256: b37c64c6583153a420c7b80b34d62d33e317b40db561dfaeef027da083debb17
+  sha256: {{ hash }}
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,9 +42,9 @@ requirements:
     - prompt_toolkit >=3.0.24,<3.0.29
     - distro >=1.5.0,<1.6.0
     - awscrt >=0.12.4,<=0.14.0
-    - python-dateutil>=2.1,<3.0.0
-    - jmespath>=0.7.1,<1.1.0
-    - urllib3>=1.25.4,<1.27
+    - python-dateutil >=2.1,<3.0.0
+    - jmespath >=0.7.1,<1.1.0
+    - urllib3 >=1.25.4,<1.27
 
   run:
     - python >=3.8
@@ -62,9 +62,9 @@ requirements:
     - prompt_toolkit >=3.0.24,<3.0.29
     - distro >=1.5.0,<1.6.0
     - awscrt >=0.12.4,<=0.14.0
-    - python-dateutil>=2.1,<3.0.0
-    - jmespath>=0.7.1,<1.1.0
-    - urllib3>=1.25.4,<1.27
+    - python-dateutil >=2.1,<3.0.0
+    - jmespath >=0.7.1,<1.1.0
+    - urllib3 >=1.25.4,<1.27
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "awscli" %}
-{% set version = "2.11.15" %}
-{% set hash = "b7762178eee6c3753cb176badbccb4bb02662ae81fec499e507faf936f9fd320" %}
+{% set version = "2.13.3" %}
+{% set hash = "c3940fdf8d4ca20aa8b1736e075dd68cef2c2581f6dbac93d1c41d149490a13b" %}
 
 package:
   name: {{ name|lower }}
@@ -30,7 +30,7 @@ requirements:
     - ruamel.yaml.clib >=0.2.0,<=0.2.7       # [build_platform != target_platform]
     - prompt_toolkit >=3.0.24,<3.0.39        # [build_platform != target_platform]
     - distro >=1.5.0,<1.9.0                  # [build_platform != target_platform]
-    - awscrt >=0.12.4,<=0.17.0               # [build_platform != target_platform]
+    - awscrt >=0.16.4,<=0.17.0               # [build_platform != target_platform]
     - python-dateutil >=2.1,<3.0.0           # [build_platform != target_platform]
     - jmespath >=0.7.1,<1.1.0                # [build_platform != target_platform]
     - urllib3 >=1.25.4,<1.27                 # [build_platform != target_platform]
@@ -53,7 +53,7 @@ requirements:
     - ruamel.yaml.clib >=0.2.0,<=0.2.7
     - prompt_toolkit >=3.0.24,<3.0.39
     - distro >=1.5.0,<1.9.0
-    - awscrt >=0.12.4,<=0.17.0
+    - awscrt >=0.16.4,<=0.17.0
     - python-dateutil >=2.1,<3.0.0
     - jmespath >=0.7.1,<1.1.0
     - urllib3 >=1.25.4,<1.27
@@ -67,7 +67,7 @@ requirements:
     - ruamel.yaml.clib >=0.2.0,<=0.2.7
     - prompt_toolkit >=3.0.24,<3.0.39
     - distro >=1.5.0,<1.9.0
-    - awscrt >=0.12.4,<=0.17.0
+    - awscrt >=0.16.4,<=0.17.0
     - python-dateutil >=2.1,<3.0.0
     - jmespath >=0.7.1,<1.1.0
     - urllib3 >=1.25.4,<1.27

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
+    - python >=3.8                           # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - python >=3.8
@@ -47,6 +47,7 @@ requirements:
     - urllib3>=1.25.4,<1.27
 
   run:
+    - python >=3.8
     # Commented lines are the original requirements from
     # https://github.com/aws/aws-cli/blob/2.8.11/pyproject.toml#L30-L40
     # They have been expanded to work with the available conda-forge packages on

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,10 @@ source:
 
 build:
   number: 0
-  noarch: python
   # Build uses pep517 with a custom backend
-  script: |
-    {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+  # console_scripts entrypoints aren't used, so this can't be noarch
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv  # [not unix]
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv && mkdir -p $PREFIX/share/bash-completions/completions && echo complete -C aws_completer aws >$PREFIX/share/bash-completions/completions/aws  # [unix]
 
 requirements:
   build:
@@ -30,12 +30,10 @@ requirements:
     # which requires importing awscli modules, so we need to install all runtime
     # dependencies too. YAML anchors don't support merging lists so we have to
     # duplicate everything :-(
-    # Commented lines are the original requirements from
+    # Requirements taken from
     # https://github.com/aws/aws-cli/blob/2.8.11/pyproject.toml#L30-L40
-    # - colorama >=0.2.5,<0.4.4
-    - colorama >=0.2.5,<0.5.0
-    # - docutils >=0.10,<0.16
-    - docutils >=0.10,<0.18
+    - colorama >=0.2.5,<0.4.4
+    - docutils >=0.10,<0.16
     - cryptography >=3.3.2,<=38.0.1
     - ruamel.yaml >=0.15.0,<=0.17.21
     - wcwidth <0.2.0
@@ -48,14 +46,8 @@ requirements:
 
   run:
     - python >=3.8
-    # Commented lines are the original requirements from
-    # https://github.com/aws/aws-cli/blob/2.8.11/pyproject.toml#L30-L40
-    # They have been expanded to work with the available conda-forge packages on
-    # more recent versions of Python
-    # - colorama >=0.2.5,<0.4.4
-    - colorama >=0.2.5,<0.5.0
-    # - docutils >=0.10,<0.16
-    - docutils >=0.10,<0.18
+    - colorama >=0.2.5,<0.4.4
+    - docutils >=0.10,<0.16
     - cryptography >=3.3.2,<=38.0.1
     - ruamel.yaml >=0.15.0,<=0.17.21
     - wcwidth <0.2.0
@@ -67,12 +59,6 @@ requirements:
     - urllib3 >=1.25.4,<1.27
 
 test:
-  commands:
-    - aws --version
-    - aws_completer
-    # Check autocomplete index exists:
-    - python -c 'import awscli, os; assert os.stat(os.path.join(os.path.dirname(awscli.__file__), "data", "ac.index")).st_size > 1e6'
-    - COMP_LINE="aws ec2 describe-inst" aws_completer     # [unix]
   imports:
     # find $CONDA_PREFIX/lib/python3.9/site-packages/awscli/ -type f -name __init__.py | sed -re 's%.+(awscli.*)/__init__.py%- \1%' -re s'%/%.%g' | sort
     # Last updated version 2.8.11
@@ -120,6 +106,13 @@ test:
     - awscli.customizations.wizard
     - awscli.customizations.wizard.ui
     - awscli.s3transfer
+
+  commands:
+    - aws --version
+    - aws_completer
+    # Check autocomplete index exists:
+    - python -c "import awscli, os; assert os.stat(os.path.join(os.path.dirname(awscli.__file__), 'data', 'ac.index')).st_size > 1e6"
+    - COMP_LINE="aws ec2 describe-inst" aws_completer     # [unix]
 
 about:
   home: https://aws.amazon.com/cli/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ build:
   # console_scripts entrypoints aren't used, so this can't be noarch
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv  # [not unix]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv && mkdir -p $PREFIX/share/bash-completions/completions && echo complete -C aws_completer aws >$PREFIX/share/bash-completions/completions/aws  # [unix]
-  skip: true  # [py<38]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,13 +17,14 @@ build:
   # console_scripts entrypoints aren't used, so this can't be noarch
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv  # [not unix]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv && mkdir -p $PREFIX/share/bash-completions/completions && echo complete -C aws_completer aws >$PREFIX/share/bash-completions/completions/aws  # [unix]
+  skip: true  # [py<38]
 
 requirements:
   build:
-    - python >=3.8                           # [build_platform != target_platform]
+    - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
-    - python >=3.8
+    - python
     - flit-core
     - pip
 
@@ -46,7 +47,7 @@ requirements:
     - urllib3 >=1.25.4,<1.27
 
   run:
-    - python >=3.8
+    - python
     - colorama >=0.2.5,<0.4.4
     - docutils >=0.10,<0.16
     - cryptography >=3.3.2,<=38.0.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    # awscrt is needed to generate the autocomplete index
+    - awscrt >=0.12.4,<=0.17.0               # [build_platform != target_platform]
   host:
     - python
     - flit-core >=3.7.1,<3.8.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,24 @@ requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    # The autocomplete index step is run on the build host
+    - colorama >=0.2.5,<0.4.7                # [build_platform != target_platform]
+    - docutils >=0.10,<0.20                  # [build_platform != target_platform]
+    - cryptography >=3.3.2,<=40.0.2          # [build_platform != target_platform]
+    - ruamel.yaml >=0.15.0,<=0.17.21         # [build_platform != target_platform]
+    - ruamel.yaml.clib >=0.2.0,<=0.2.7       # [build_platform != target_platform]
+    - prompt_toolkit >=3.0.24,<3.0.39        # [build_platform != target_platform]
+    - distro >=1.5.0,<1.9.0                  # [build_platform != target_platform]
+    - awscrt >=0.12.4,<=0.17.0               # [build_platform != target_platform]
+    - python-dateutil >=2.1,<3.0.0           # [build_platform != target_platform]
+    - jmespath >=0.7.1,<1.1.0                # [build_platform != target_platform]
+    - urllib3 >=1.25.4,<1.27                 # [build_platform != target_platform]
+
+  host:
+    - python
+    - flit-core >=3.7.1,<3.8.1
+    - pip
+
     # The build process generates the autocomplete index (scripts/gen-ac-index)
     # which requires importing awscli modules, so we need to install all runtime
     # dependencies too. YAML anchors don't support merging lists so we have to
@@ -39,11 +57,6 @@ requirements:
     - python-dateutil >=2.1,<3.0.0
     - jmespath >=0.7.1,<1.1.0
     - urllib3 >=1.25.4,<1.27
-
-  host:
-    - python
-    - flit-core >=3.7.1,<3.8.1
-    - pip
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,64 +1,124 @@
 {% set name = "awscli" %}
-{% set version = "1.27.8" %}
-{% set hash = "21a9f2339bb3b4a9e14e12da1e4f64f9c08b1b495f869fda793d935c0e3995ea" %}
-
-{% set vmajor,vminor,vpatch = version.split('.') %}
-# ALWAYS DOUBLE-CHECK THESE OFFSETS AGAINST UPSTREAM setup.py
-{% set botocore_major = vmajor | int + 0 %}
-{% set botocore_minor = vminor | int + 2 %}
-{% set botocore_patch = vpatch | int + 0 %}
-{% set botocore_pin = botocore_major ~ '.' ~ botocore_minor ~ '.' ~ botocore_patch %}
+{% set version = "2.8.11" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
+# v2 is not on PyPI https://github.com/aws/aws-cli/issues/6785
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ hash }}
+  url: https://github.com/aws/aws-cli/archive/{{ version }}.tar.gz
+  sha256: b37c64c6583153a420c7b80b34d62d33e317b40db561dfaeef027da083debb17
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv  # [not unix]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv && mkdir -p $PREFIX/share/bash-completions/completions && echo complete -C aws_completer aws >$PREFIX/share/bash-completions/completions/aws  # [unix]
+  noarch: python
+  # Build uses pep517 with a custom backend
+  script: |
+    {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
-    - python
-#    - python >=3.7
+    - python >=3.8
+    - flit-core
     - pip
 
+    # The build process generates the autocomplete index (scripts/gen-ac-index)
+    # which requires importing awscli modules, so we need to install all runtime
+    # dependencies too. YAML anchors don't support merging lists so we have to
+    # duplicate everything :-(
+    # Commented lines are the original requirements from
+    # https://github.com/aws/aws-cli/blob/2.8.11/pyproject.toml#L30-L40
+    # - colorama >=0.2.5,<0.4.4
+    - colorama >=0.2.5,<0.5.0
+    # - docutils >=0.10,<0.16
+    - docutils >=0.10,<0.18
+    - cryptography >=3.3.2,<=38.0.1
+    - ruamel.yaml >=0.15.0,<=0.17.21
+    - wcwidth <0.2.0
+    - prompt_toolkit >=3.0.24,<3.0.29
+    - distro >=1.5.0,<1.6.0
+    - awscrt >=0.12.4,<=0.14.0
+    - python-dateutil>=2.1,<3.0.0
+    - jmespath>=0.7.1,<1.1.0
+    - urllib3>=1.25.4,<1.27
+
   run:
-    - python
-#    - python >=3.7
-    - botocore =={{ botocore_pin }}
-    - colorama >=0.2.5,<0.4.5
-    - docutils >=0.10,<0.17
-    - rsa >=3.1.2,<4.8
-    - s3transfer >=0.6.0,<0.7.0
-    - pyyaml >=3.10,<5.5
+    # Commented lines are the original requirements from
+    # https://github.com/aws/aws-cli/blob/2.8.11/pyproject.toml#L30-L40
+    # They have been expanded to work with the available conda-forge packages on
+    # more recent versions of Python
+    # - colorama >=0.2.5,<0.4.4
+    - colorama >=0.2.5,<0.5.0
+    # - docutils >=0.10,<0.16
+    - docutils >=0.10,<0.18
+    - cryptography >=3.3.2,<=38.0.1
+    - ruamel.yaml >=0.15.0,<=0.17.21
+    - wcwidth <0.2.0
+    - prompt_toolkit >=3.0.24,<3.0.29
+    - distro >=1.5.0,<1.6.0
+    - awscrt >=0.12.4,<=0.14.0
+    - python-dateutil>=2.1,<3.0.0
+    - jmespath>=0.7.1,<1.1.0
+    - urllib3>=1.25.4,<1.27
 
 test:
+  commands:
+    - aws --version
+    - aws_completer
+    # Check autocomplete index exists:
+    - python -c 'import awscli, os; assert os.stat(os.path.join(os.path.dirname(awscli.__file__), "data", "ac.index")).st_size > 1e6'
+    - COMP_LINE="aws ec2 describe-inst" aws_completer     # [unix]
   imports:
+    # find $CONDA_PREFIX/lib/python3.9/site-packages/awscli/ -type f -name __init__.py | sed -re 's%.+(awscli.*)/__init__.py%- \1%' -re s'%/%.%g' | sort
+    # Last updated version 2.8.11
     - awscli
+    - awscli.autocomplete
+    - awscli.autocomplete.local
+    - awscli.autocomplete.serverside
+    - awscli.autocomplete.serverside.custom_completers
+    - awscli.autocomplete.serverside.custom_completers.ddb
+    - awscli.autocomplete.serverside.custom_completers.logs
+    - awscli.autoprompt
+    - awscli.bcdoc
+    - awscli.botocore
+    - awscli.botocore.crt
+    - awscli.botocore.docs
+    - awscli.botocore.docs.bcdoc
+    - awscli.botocore.retries
+    - awscli.botocore.vendored
+    - awscli.botocore.vendored.requests
+    - awscli.botocore.vendored.requests.packages
+    - awscli.botocore.vendored.requests.packages.urllib3
     - awscli.customizations
+    - awscli.customizations.cloudformation
     - awscli.customizations.cloudtrail
+    - awscli.customizations.codeartifact
     - awscli.customizations.codedeploy
     - awscli.customizations.configservice
     - awscli.customizations.configure
     - awscli.customizations.datapipeline
+    - awscli.customizations.dlm
+    - awscli.customizations.dynamodb
     - awscli.customizations.ec2
+    - awscli.customizations.ecs
+    - awscli.customizations.eks
     - awscli.customizations.emr
+    - awscli.customizations.emrcontainers
     - awscli.customizations.gamelift
+    - awscli.customizations.history
+    - awscli.customizations.lightsail
+    - awscli.customizations.logs
     - awscli.customizations.s3
     - awscli.customizations.s3.syncstrategy
-  commands:
-    - test -f $PREFIX/bin/aws_completer                   # [unix]
-    - COMP_LINE="aws ec2 describe-inst" aws_completer     # [unix]
+    - awscli.customizations.servicecatalog
+    - awscli.customizations.sso
+    - awscli.customizations.wizard
+    - awscli.customizations.wizard.ui
+    - awscli.s3transfer
 
 about:
   home: https://aws.amazon.com/cli/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "awscli" %}
-{% set version = "2.8.12" %}
-{% set hash = "a1f16a8e0bb7fb098967f852b074f431ec4adbdfa51e714129945c67a9798537" %}
+{% set version = "2.11.15" %}
+{% set hash = "b7762178eee6c3753cb176badbccb4bb02662ae81fec499e507faf936f9fd320" %}
 
 package:
   name: {{ name|lower }}
@@ -24,7 +24,7 @@ requirements:
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - python
-    - flit-core
+    - flit-core >=3.7.1,<3.8.1
     - pip
 
     # The build process generates the autocomplete index (scripts/gen-ac-index)
@@ -32,29 +32,29 @@ requirements:
     # dependencies too. YAML anchors don't support merging lists so we have to
     # duplicate everything :-(
     # Requirements taken from
-    # https://github.com/aws/aws-cli/blob/2.8.11/pyproject.toml#L30-L40
-    - colorama >=0.2.5,<0.4.4
-    - docutils >=0.10,<0.16
-    - cryptography >=3.3.2,<=38.0.1
+    # https://github.com/aws/aws-cli/blob/2.11.15/pyproject.toml#L30-L46
+    - colorama >=0.2.5,<0.4.7
+    - docutils >=0.10,<0.20
+    - cryptography >=3.3.2,<=40.0.2
     - ruamel.yaml >=0.15.0,<=0.17.21
-    - wcwidth <0.2.0
-    - prompt_toolkit >=3.0.24,<3.0.29
-    - distro >=1.5.0,<1.6.0
-    - awscrt >=0.12.4,<=0.14.0
+    - ruamel.yaml.clib >=0.2.0,<=0.2.7
+    - prompt_toolkit >=3.0.24,<3.0.39
+    - distro >=1.5.0,<1.9.0
+    - awscrt >=0.12.4,<=0.17.0
     - python-dateutil >=2.1,<3.0.0
     - jmespath >=0.7.1,<1.1.0
     - urllib3 >=1.25.4,<1.27
 
   run:
     - python
-    - colorama >=0.2.5,<0.4.4
-    - docutils >=0.10,<0.16
-    - cryptography >=3.3.2,<=38.0.1
+    - colorama >=0.2.5,<0.4.7
+    - docutils >=0.10,<0.20
+    - cryptography >=3.3.2,<=40.0.2
     - ruamel.yaml >=0.15.0,<=0.17.21
-    - wcwidth <0.2.0
-    - prompt_toolkit >=3.0.24,<3.0.29
-    - distro >=1.5.0,<1.6.0
-    - awscrt >=0.12.4,<=0.14.0
+    - ruamel.yaml.clib >=0.2.0,<=0.2.7
+    - prompt_toolkit >=3.0.24,<3.0.39
+    - distro >=1.5.0,<1.9.0
+    - awscrt >=0.12.4,<=0.17.0
     - python-dateutil >=2.1,<3.0.0
     - jmespath >=0.7.1,<1.1.0
     - urllib3 >=1.25.4,<1.27
@@ -62,7 +62,7 @@ requirements:
 test:
   imports:
     # find $CONDA_PREFIX/lib/python3.9/site-packages/awscli/ -type f -name __init__.py | sed -re 's%.+(awscli.*)/__init__.py%- \1%' -re s'%/%.%g' | sort
-    # Last updated version 2.8.11
+    # Last updated version 2.11.15
     - awscli
     - awscli.autocomplete
     - awscli.autocomplete.local

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,13 +22,6 @@ requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    # awscrt is needed to generate the autocomplete index
-    - awscrt >=0.12.4,<=0.17.0               # [build_platform != target_platform]
-  host:
-    - python
-    - flit-core >=3.7.1,<3.8.1
-    - pip
-
     # The build process generates the autocomplete index (scripts/gen-ac-index)
     # which requires importing awscli modules, so we need to install all runtime
     # dependencies too. YAML anchors don't support merging lists so we have to
@@ -46,6 +39,11 @@ requirements:
     - python-dateutil >=2.1,<3.0.0
     - jmespath >=0.7.1,<1.1.0
     - urllib3 >=1.25.4,<1.27
+
+  host:
+    - python
+    - flit-core >=3.7.1,<3.8.1
+    - pip
 
   run:
     - python


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Closes https://github.com/conda-forge/awscli-feedstock/issues/828


AWSCLI version 2 now supports PEP517 builds, and also bundles botocore and s3transfer under `awscli.*`: https://github.com/aws/aws-cli/issues/6785
This removes the blockers to packaging v2 in conda-forge

I've built this package and pushed it to my channel, to test it:
```
mamba create -n test-env -c manics -c conda-forge awscli=2.8.11
```

It probably makes sense to keep the version 1 around, so either a new `v2` branch could be created, or the default `main` branch could be kept for v2 and a new `v1` branch created?
https://conda-forge.org/docs/maintainer/updating_pkgs.html#maintaining-several-versions
