### PR TITLE
adjust indentation of yaml comments

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 0
+  number: 1
   script:
     - {{ PYTHON }} -m pip install . --no-deps -vv
     - mkdir -p $PREFIX/share/bash-completions/completions && echo complete -C aws_completer aws >$PREFIX/share/bash-completions/completions/aws  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,13 +23,13 @@ requirements:
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - python
-#    - python >=3.8
+    #- python >=3.8
     - pip
     - setuptools
 
   run:
     - python
-#    - python >=3.8
+    #- python >=3.8
     - botocore ==1.35.83
     - colorama >=0.2.5,<0.4.7
     - docutils >=0.10,<0.17


### PR DESCRIPTION
for conda-recipe-manager linting

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
ref https://github.com/conda-incubator/conda-recipe-manager/issues/222
not sure why conda-recipe-manager is doing its own hand rolled yaml parsing instead of using a standard one